### PR TITLE
cargo: update to 0.11.0

### DIFF
--- a/recipes-devtools/cargo/cargo_0.11.0.bb
+++ b/recipes-devtools/cargo/cargo_0.11.0.bb
@@ -2,16 +2,17 @@ require cargo-snapshot.inc
 require cargo.inc
 
 SRC_URI += " \
-	https://github.com/rust-lang/cargo/archive/${PV}.tar.gz;name=cargo \
+	git://github.com/rust-lang/cargo.git;protocol=https;name=cargo \
 	file://0001-disable-cargo-snapshot-fetch.patch \
-	git://github.com/rust-lang/rust-installer.git;protocol=https;name=rust-installer;destsuffix=${BP}/src/rust-installer \
+	git://github.com/rust-lang/rust-installer.git;protocol=https;name=rust-installer;destsuffix=${S}/src/rust-installer \
 "
-SRC_URI[cargo.md5sum] = "98ab2a422634d447152380898a974b08"
-SRC_URI[cargo.sha256sum] = "1e73c038681fe308195427b71322a6350c65d3b8cbea199e45c7b672b4754e0e"
+# Compatible with Rust 1.10.0
+# https://static.rust-lang.org/dist/channel-rust-1.10.0.toml
+SRCREV_cargo = "259324cd8f9bb6e1068a3a2b77685e90fda3e3b6"
 
 SRCREV_rust-installer = "c37d3747da75c280237dc2d6b925078e69555499"
 
-S = "${WORKDIR}/${BP}"
+S = "${WORKDIR}/git"
 
 LIC_FILES_CHKSUM ="\
 	file://LICENSE-MIT;md5=362255802eb5aa87810d12ddf3cfedb4 \
@@ -26,8 +27,8 @@ SRC_URI += "\
        file://curl-rust/0002-remove-per-triple-deps-on-openssl-sys.patch;patchdir=../curl-rust \
 "
 
-# 0.2.14  / -sys 0.1.29
-SRCREV_curl-rust = "76172b3ebf958fcf0b10d400f19ee02486a80ee7"
+# 0.2.19  / -sys 0.1.34
+SRCREV_curl-rust = "45b8cb56fbed45f828f96bdd8c286b2b3a8a26cb"
 
 SRCREV_FORMAT .= "_curl-rust"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/curl-rust"
@@ -50,8 +51,8 @@ SRC_URI += "\
 	file://git2-rs/0001-libgit2-sys-avoid-blessed-triples.patch;patchdir=../git2-rs \
 "
 
-# 0.3.3 / -sys 0.3.8
-SRCREV_git2-rs = "19b6873c1fad7dc93c9c2dac4cba339dacf16efa"
+# 0.4.3 / -sys 0.4.2
+SRCREV_git2-rs = "cd14fc7801e70d3b26a4e7e5d94785af1f7e9e58"
 
 SRCREV_FORMAT .= "_git2-rs"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/git2-rs"

--- a/recipes-devtools/cargo/files/curl-rust/0001-curl-sys-avoid-explicitly-linking-in-openssl.patch
+++ b/recipes-devtools/cargo/files/curl-rust/0001-curl-sys-avoid-explicitly-linking-in-openssl.patch
@@ -1,4 +1,4 @@
-From 6d74b6af6a23e195fc54c81a9bbdb21e7d5b6414 Mon Sep 17 00:00:00 2001
+From 8f82cc69e50e7c8e48a2e20b7061483a28bd0d7f Mon Sep 17 00:00:00 2001
 From: Cody P Schafer <dev@codyps.com>
 Date: Sat, 12 Dec 2015 22:36:26 -0500
 Subject: [PATCH 1/2] curl-sys: avoid explicitly linking in openssl
@@ -6,21 +6,26 @@ Subject: [PATCH 1/2] curl-sys: avoid explicitly linking in openssl
 linking libcurl with libssl is handled by pkg-config, not us
 This also allows non-blessed triples to work.
 ---
- curl-sys/Cargo.toml | 26 --------------------------
+ curl-sys/Cargo.toml | 38 --------------------------------------
  curl-sys/lib.rs     |  2 --
- 2 files changed, 28 deletions(-)
+ 2 files changed, 40 deletions(-)
 
 diff --git a/curl-sys/Cargo.toml b/curl-sys/Cargo.toml
-index bf994bf..f153039 100644
+index 24bc4fa..dd56209 100644
 --- a/curl-sys/Cargo.toml
 +++ b/curl-sys/Cargo.toml
-@@ -19,29 +19,3 @@ path = "lib.rs"
+@@ -19,42 +19,4 @@ path = "lib.rs"
  [dependencies]
  libz-sys = ">= 0"
  libc = "0.2"
 -
+-[target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
+-openssl-sys = ">= 0"
+-
 -# Unix platforms use OpenSSL for now to provide SSL functionality
 -[target.i686-unknown-linux-gnu.dependencies]
+-openssl-sys = ">= 0"
+-[target.i586-unknown-linux-gnu.dependencies]
 -openssl-sys = ">= 0"
 -[target.i686-linux-android.dependencies]
 -openssl-sys = ">= 0"
@@ -30,9 +35,17 @@ index bf994bf..f153039 100644
 -openssl-sys = ">= 0"
 -[target.arm-unknown-linux-gnueabihf.dependencies]
 -openssl-sys = ">= 0"
+-[target.armv7-unknown-linux-gnueabihf.dependencies]
+ openssl-sys = "0.7.0"
 -[target.arm-linux-androideabi.dependencies]
 -openssl-sys = ">= 0"
 -[target.aarch64-unknown-linux-gnu.dependencies]
+-openssl-sys = ">= 0"
+-[target.powerpc-unknown-linux-gnu.dependencies]
+-openssl-sys = ">= 0"
+-[target.powerpc64-unknown-linux-gnu.dependencies]
+-openssl-sys = ">= 0"
+-[target.powerpc64le-unknown-linux-gnu.dependencies]
 -openssl-sys = ">= 0"
 -[target.i686-unknown-freebsd.dependencies]
 -openssl-sys = ">= 0"
@@ -45,7 +58,7 @@ index bf994bf..f153039 100644
 -[target.x86_64-unknown-dragonfly.dependencies]
 -openssl-sys = ">= 0"
 diff --git a/curl-sys/lib.rs b/curl-sys/lib.rs
-index be80469..b53b445 100644
+index 7990bd6..eb6c27a 100644
 --- a/curl-sys/lib.rs
 +++ b/curl-sys/lib.rs
 @@ -3,8 +3,6 @@
@@ -58,5 +71,5 @@ index be80469..b53b445 100644
  use libc::{c_void, c_int, c_char, c_uint, c_long};
  
 -- 
-2.4.10
+2.9.2
 

--- a/recipes-devtools/cargo/files/curl-rust/0002-remove-per-triple-deps-on-openssl-sys.patch
+++ b/recipes-devtools/cargo/files/curl-rust/0002-remove-per-triple-deps-on-openssl-sys.patch
@@ -1,17 +1,17 @@
-From 445289f4eacc5c048e4a455bb6d6a6a2b9995e88 Mon Sep 17 00:00:00 2001
+From eb23b1b6f749102e3db92b73a5e55ec6ad688524 Mon Sep 17 00:00:00 2001
 From: Cody P Schafer <dev@codyps.com>
 Date: Sat, 12 Dec 2015 22:40:33 -0500
 Subject: [PATCH 2/2] remove per triple deps on openssl-sys
 
 ---
- Cargo.toml | 27 +--------------------------
- 1 file changed, 1 insertion(+), 26 deletions(-)
+ Cargo.toml | 40 +---------------------------------------
+ 1 file changed, 1 insertion(+), 39 deletions(-)
 
 diff --git a/Cargo.toml b/Cargo.toml
-index 74f63c8..28aa1fa 100644
+index 5f6cf87..0c87156 100644
 --- a/Cargo.toml
 +++ b/Cargo.toml
-@@ -12,36 +12,11 @@ url = "0.2.0"
+@@ -12,49 +12,11 @@ url = ">= 0.5, < 2.0"
  log = "0.3.0"
  libc = "0.2"
  curl-sys = { path = "curl-sys", version = "0.1.0" }
@@ -21,7 +21,12 @@ index 74f63c8..28aa1fa 100644
  env_logger = "0.3.0"
  
 -# Unix platforms use OpenSSL for now to provide SSL functionality
+-[target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
+-openssl-sys = "0.7.0"
+-
 -[target.i686-unknown-linux-gnu.dependencies]
+-openssl-sys = "0.7.0"
+-[target.i586-unknown-linux-gnu.dependencies]
 -openssl-sys = "0.7.0"
 -[target.i686-linux-android.dependencies]
 -openssl-sys = "0.7.0"
@@ -31,9 +36,17 @@ index 74f63c8..28aa1fa 100644
 -openssl-sys = "0.7.0"
 -[target.arm-unknown-linux-gnueabihf.dependencies]
 -openssl-sys = "0.7.0"
+-[target.armv7-unknown-linux-gnueabihf.dependencies]
+-openssl-sys = "0.7.0"
 -[target.arm-linux-androideabi.dependencies]
 -openssl-sys = "0.7.0"
 -[target.aarch64-unknown-linux-gnu.dependencies]
+-openssl-sys = "0.7.0"
+-[target.powerpc-unknown-linux-gnu.dependencies]
+-openssl-sys = "0.7.0"
+-[target.powerpc64-unknown-linux-gnu.dependencies]
+-openssl-sys = "0.7.0"
+-[target.powerpc64le-unknown-linux-gnu.dependencies]
 -openssl-sys = "0.7.0"
 -[target.i686-unknown-freebsd.dependencies]
 -openssl-sys = "0.7.0"
@@ -50,5 +63,5 @@ index 74f63c8..28aa1fa 100644
  
  name = "test"
 -- 
-2.4.10
+2.9.2
 

--- a/recipes-devtools/cargo/files/git2-rs/0001-libgit2-sys-avoid-blessed-triples.patch
+++ b/recipes-devtools/cargo/files/git2-rs/0001-libgit2-sys-avoid-blessed-triples.patch
@@ -1,17 +1,17 @@
-From 95709b3f5b1495a57043975d7100461feed46b2f Mon Sep 17 00:00:00 2001
+From 308fd350907fba13f68dcdb8e48040582466cae6 Mon Sep 17 00:00:00 2001
 From: Cody P Schafer <dev@codyps.com>
 Date: Sat, 12 Dec 2015 22:53:37 -0500
 Subject: [PATCH] libgit2-sys: avoid blessed triples
 
 ---
- libgit2-sys/Cargo.toml | 22 +---------------------
- 1 file changed, 1 insertion(+), 21 deletions(-)
+ libgit2-sys/Cargo.toml | 33 +--------------------------------
+ 1 file changed, 1 insertion(+), 32 deletions(-)
 
 diff --git a/libgit2-sys/Cargo.toml b/libgit2-sys/Cargo.toml
-index 15b28d8..3590878 100644
+index 2395314..29000ef 100644
 --- a/libgit2-sys/Cargo.toml
 +++ b/libgit2-sys/Cargo.toml
-@@ -17,32 +17,12 @@ path = "lib.rs"
+@@ -17,44 +17,13 @@ path = "lib.rs"
  libssh2-sys = { version = ">= 0", optional = true }
  libc = "0.2"
  libz-sys = ">= 0"
@@ -20,8 +20,14 @@ index 15b28d8..3590878 100644
  [build-dependencies]
  pkg-config = "0.3"
  cmake = "0.1.2"
+ gcc = "0.3"
  
+-[target."cfg(all(unix, not(target_os = \"macos\")))".dependencies]
+-openssl-sys = "0.7.0"
+-
 -[target.i686-unknown-linux-gnu.dependencies]
+-openssl-sys = "0.7.0"
+-[target.i586-unknown-linux-gnu.dependencies]
 -openssl-sys = "0.7.0"
 -[target.x86_64-unknown-linux-gnu.dependencies]
 -openssl-sys = "0.7.0"
@@ -29,7 +35,13 @@ index 15b28d8..3590878 100644
 -openssl-sys = "0.7.0"
 -[target.aarch64-unknown-linux-gnu.dependencies]
 -openssl-sys = "0.7.0"
+-[target.powerpc64-unknown-linux-gnu.dependencies]
+-openssl-sys = "0.7.0"
+-[target.powerpc64le-unknown-linux-gnu.dependencies]
+-openssl-sys = "0.7.0"
 -[target.arm-unknown-linux-gnueabihf.dependencies]
+-openssl-sys = "0.7.0"
+-[target.armv7-unknown-linux-gnueabihf.dependencies]
 -openssl-sys = "0.7.0"
 -[target.i686-unknown-freebsd.dependencies]
 -openssl-sys = "0.7.0"
@@ -46,5 +58,5 @@ index 15b28d8..3590878 100644
  ssh = ["libssh2-sys"]
  https = []
 -- 
-2.4.10
+2.9.2
 


### PR DESCRIPTION
This is the compatible version shipped with Rust 1.10.0. Use the git
hash from the release TOML file so there is no ambiguity.

Update git2 and curl dependencies and patches to match those in
Cargo.lock.

Note: does not build with 1.7.
